### PR TITLE
Feature/platform as input

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 NO_USE_BINARIES=""
 VERBOSE_MODE=""

--- a/step.sh
+++ b/step.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 NO_USE_BINARIES=""
 VERBOSE_MODE=""
@@ -26,4 +26,4 @@ fi
 
 #
 # Run carthage command
-carthage "${carthage_command}" --"${platform}" ${NO_USE_BINARIES} ${VERBOSE_MODE}
+carthage "${carthage_command}" --platform "${platform}" ${NO_USE_BINARIES} ${VERBOSE_MODE}

--- a/step.sh
+++ b/step.sh
@@ -25,5 +25,5 @@ if [ ! -z "${working_dir}" ] ; then
 fi
 
 #
-# Bootstrap
-carthage "${carthage_command}" --platform iOS ${NO_USE_BINARIES} ${VERBOSE_MODE}
+# Run carthage command
+carthage "${carthage_command}" --"${platform}" iOS ${NO_USE_BINARIES} ${VERBOSE_MODE}

--- a/step.sh
+++ b/step.sh
@@ -26,4 +26,4 @@ fi
 
 #
 # Run carthage command
-carthage "${carthage_command}" --"${platform}" iOS ${NO_USE_BINARIES} ${VERBOSE_MODE}
+carthage "${carthage_command}" --"${platform}" ${NO_USE_BINARIES} ${VERBOSE_MODE}

--- a/step.yml
+++ b/step.yml
@@ -63,4 +63,4 @@ inputs:
       value_options:
       - "iOS"
       - "Mac"
-      - "iOS, Mac"
+      - "iOS,Mac"

--- a/step.yml
+++ b/step.yml
@@ -55,3 +55,12 @@ inputs:
       description: |
         This directory will be set as the current working
         directory for the carthage command.
+  - platform: "iOS"
+    opts:
+      title: "Platform"
+      description: |
+        Choose which platform to build your dependencies for.
+      value_options:
+      - "iOS"
+      - "Mac"
+      - "iOS, Mac"


### PR DESCRIPTION
Make `platform` an input param, letting `carthage` to build for Mac as well.
