### PR TITLE
Fix a crash on empty working_dir variable

### DIFF
--- a/step.swift
+++ b/step.swift
@@ -33,7 +33,7 @@ func collectArgs(env: [String : String]) -> ArgsArray {
 let env = NSProcessInfo.processInfo().environment
 let task = NSTask()
 
-if let workingDir = env["working_dir"] as String! {
+if let workingDir = env["working_dir"] where workingDir != "" {
     task.currentDirectoryPath = workingDir
 }
 


### PR DESCRIPTION
As of 25 Apr 2016, the step crashes at runtime on Bitrise with the following stack trace:

``` none
2016-04-25 04:13:25.573 swift[962:4964] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'working directory doesn't exist.'
*** First throw call stack:
(
    0   CoreFoundation                      0x00007fff9cd084f2 __exceptionPreprocess + 178
    1   libobjc.A.dylib                     0x00007fff8cb3d73c objc_exception_throw + 48
    2   CoreFoundation                      0x00007fff9cd6f4bd +[NSException raise:format:] + 205
    3   Foundation                          0x00007fff925e708b -[NSConcreteTask launchWithDictionary:] + 620
    4   ???                                 0x000000010ad2ac2c 0x0 + 4476546092
    5   swift                               0x0000000106bf6b31 _ZN4llvm5MCJIT11runFunctionEPNS_8FunctionENS_8ArrayRefINS_12GenericValueEEE + 545
    6   swift                               0x0000000106bf92ff _ZN4llvm15ExecutionEngine17runFunctionAsMainEPNS_8FunctionERKNSt3__16vectorINS3_12basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEENS8_ISA_EEEEPKPKc + 1167
    7   swift                               0x0000000106ae89ec _ZN5swift14RunImmediatelyERNS_16CompilerInstanceERKNSt3__16vectorINS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEENS7_IS9_EEEERNS_12IRGenOptionsERKNS_10SILOptionsE + 1916
    8   swift                               0x00000001066dc94d _ZL14performCompileRN5swift16CompilerInstanceERNS_18CompilerInvocationEN4llvm8ArrayRefIPKcEERi + 14797
    9   swift                               0x00000001066d841d _Z13frontend_mainN4llvm8ArrayRefIPKcEES2_Pv + 2781
    10  swift                               0x00000001066d3e3c main + 1932
    11  libdyld.dylib                       0x00007fff8dbbc5ad start + 1
    12  ???                                 0x000000000000000b 0x0 + 11
)
```

The problem lies beneath `working_dir` environment variable, which, after Bitrise CLI 1.3.0, is set to an empty string `""`, instead of being omitted.

This pull request fixes the crash by making sure working directory isn't set to `""`.
