### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Plain simple build step for setting up your project with [Carthage](https://gith
 You can cache the result of `carthage bootstrap` to make Bitrise faster when building unchanged dependencies. For that you'll have to [set up caching](http://devcenter.bitrise.io/caching/about-caching/) in your Bitrise workflow.
 
 1. add a cache pull step before your Carthage step,
-2. set up a cache push step after your Carthage step and make sure to add `./Carthage -> ./Carthage/Cachefile`.
+2. set up a cache push step after your Carthage step and make sure to add:
+ * If you use Carthage v0.20.0 or later, `./Carthage`.
+ * Otherwise, `./Carthage -> ./Carthage/Cachefile`.
 
 The `Cachefile` stores a Swift version you ran `carthage bootstrap` the last time and the content of your `Cartfile.resolved`. Until either of these information is not changed between builds, Bitrise will ignore the `bootstrap` call and use the cached content of your `Carthage/Build` directory for building your project. If you have changes in your `Cartfile.resolved`, or changed the stack to one with a different Swift version, it will run `carthage bootstrap` to make sure the cache is only used when it's 100% compatible.
 


### PR DESCRIPTION
Seems that it no longer updates `./Carthage/Cachefile` if the version of Carthage is v0.20.0 or later and uses native one.
https://github.com/bitrise-steplib/steps-carthage/blob/master/main.go#L296

