### PR TITLE
Add ability to point to point to custom xcconfig via env var (Xcode 12 workaround)

### DIFF
--- a/main.go
+++ b/main.go
@@ -306,8 +306,9 @@ func main() {
 	if configs.Xcconfig != "" {
 		log.Printf("Appending XCODE_XCCONFIG_FILE to process environments")
 	
+		xcconfigPath := filepath.Join(projectDir, string(configs.Xcconfig))
 		cmd.AppendEnvs(fmt.Sprintf("XCODE_XCCONFIG_FILE=%s",
-		string(configs.Xcconfig)))
+		xcconfigPath))
 	}
 	
 	cmd.SetStdout(os.Stdout)

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ type Config struct {
 	CarthageCommand   string          `env:"carthage_command,required"`
 	CarthageOptions   string          `env:"carthage_options"`
 	SourceDir         string          `env:"BITRISE_SOURCE_DIR"`
+	Xcconfig          string          `env:"xcconfig"`
 
 	// Debug
 	VerboseLog bool `env:"verbose_log,opt[yes,no]"`

--- a/main.go
+++ b/main.go
@@ -301,7 +301,14 @@ func main() {
 
 		cmd.AppendEnvs(fmt.Sprintf("GITHUB_ACCESS_TOKEN=%s", string(configs.GithubAccessToken)))
 	}
-
+	
+	if configs.Xcconfig != "" {
+		log.Printf("Appending XCODE_XCCONFIG_FILE to process environments")
+	
+		cmd.AppendEnvs(fmt.Sprintf("XCODE_XCCONFIG_FILE=%s",
+		string(configs.Xcconfig)))
+	}
+	
 	cmd.SetStdout(os.Stdout)
 	cmd.SetStderr(os.Stderr)
 

--- a/step.yml
+++ b/step.yml
@@ -91,3 +91,9 @@ inputs:
       value_options:
       - "yes"
       - "no"
+  - xcconfig:
+    opts:
+      title: Custom xcconfig file to add to Carthage environment
+      description: |
+        Use this to point to a custom xcconfig file to workaround Xcode 12 issue
+        see [the Github issue](https://github.com/Carthage/Carthage/issues/3019) for more info


### PR DESCRIPTION
There is a major known issue (https://github.com/Carthage/Carthage/issues/3019) building dependencies with Carthage using Xcode 12, and the best current workaround (https://github.com/Carthage/Carthage/issues/3019#issuecomment-693302447) involves specifying a custom `.xcconfig` file via an environment variable. 

This PR updates the Carthage Bitrise step to be compatible with this workaround, by adding the ability to specify a `.xcconfig` file to be added to the environment. 

This PR will also address this issue: https://github.com/bitrise-steplib/steps-carthage/issues/60
