### PR TITLE
Remove unused workflows

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,18 +12,6 @@ workflows:
           inputs:
             - workflow: e2e
 
-  ci:
-    after_run:
-      - check
-      - e2e
-
-  test-xcconfig-from-input:
-    steps:
-      - bitrise-run:
-          inputs:
-            - bitrise_config_path: "e2e/bitrise.yml"
-            - workflow_id: "test_xcconfig_from_input"
-
   sample:
     envs:
       - ORIG_BITRISE_SOURCE_DIR: $BITRISE_SOURCE_DIR


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

Remove old validation workflows that were used in the old CI setup. These are not used anymore and only `check` and `e2e` are needed.

Part of https://bitrise.atlassian.net/browse/STEP-1144
